### PR TITLE
Add flight termination directory

### DIFF
--- a/flight_termination/README
+++ b/flight_termination/README
@@ -1,0 +1,32 @@
+# Flight Termaination
+
+## Overview
+Contains code for handling Flight Termination. This includes code that will run on the drone and the Ground Control Station (GCS).
+
+## Setup
+
+1. Clone the repository:
+
+    ```bash
+    git clone https://github.com/UMUAS/Nav2023-2024.git
+    ```
+
+2. Navigate to the `flight_termination` directory:
+
+    ```bash
+    cd Nav2023-2024
+    cd flight_termination
+    ```
+
+3. Create, then activate a Python Virtual Environment (Recommended):
+
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    ```
+
+4. Install Dependencies:
+
+    ```bash
+    python -m pip install -r requirements.txt
+    ```


### PR DESCRIPTION
Add a flight termination directory which includes a `README` and a `requirements.txt` file containing all packages required to run the flight termination code. **If we are to make these into packages, then this setup will change quite a bit**.